### PR TITLE
Remove inheritance of non-existent interface.

### DIFF
--- a/VendingMachine/CoinInHopper.cs
+++ b/VendingMachine/CoinInHopper.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace VendingMachine
 {
-    class CoinInHopper : ICoinSlot
+    class CoinInHopper
     {
         public CoinInHopper(Action coinInsertedAction)
         {


### PR DESCRIPTION
The ICoinSlot interface may have once existed, but it doesn't anymore.
